### PR TITLE
[Feat] 자회선 조회 api 구현 /#18

### DIFF
--- a/api/endpoints/uv_index.py
+++ b/api/endpoints/uv_index.py
@@ -1,9 +1,5 @@
-# api/endpoints/uv_index.py
-
-from fastapi import APIRouter, HTTPException, Path
-
-# 이 import 구문들이 절대 경로로 되어 있는지 확인!
-from services import uv_index as uv_service
+from fastapi import APIRouter, HTTPException
+from services.uv_index import fetch_korea_uv_range
 from schema.uv_index import UVIndexResponse
 
 router = APIRouter(
@@ -11,12 +7,23 @@ router = APIRouter(
     tags=["UV Index"]
 )
 
-@router.get("/{area_code}", response_model=UVIndexResponse, summary="특정 지역의 자외선 지수 조회")
-async def get_uv_index(
-    area_code: str = Path(..., min_length=8, max_length=10, description="조회할 지역의 코드", example="11B10101")
-):
+@router.get(
+    "/", 
+    response_model=UVIndexResponse,
+    summary="대한민국 자외선 지수 범위 조회",
+    description="대한민국 전체의 자외선 지수 최저~최고 범위를 조회합니다."
+)
+async def get_korea_uv_range():
+    """
+    대한민국 전체의 자외선 지수 범위를 조회합니다.
+    
+    - 전국 주요 지역의 UV 지수를 실시간으로 조회
+    - 최저~최고 범위로 표시
+    - 어제와의 차이 제공
+    """
     try:
-        uv_data = await uv_service.fetch_uv_index_from_kma(area_code)
-        return uv_data
-    except HTTPException as e:
-        raise e
+        return await fetch_korea_uv_range()
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail="서버 내부 오류가 발생했습니다.") 

--- a/api/endpoints/uv_index.py
+++ b/api/endpoints/uv_index.py
@@ -1,0 +1,22 @@
+# api/endpoints/uv_index.py
+
+from fastapi import APIRouter, HTTPException, Path
+
+# 이 import 구문들이 절대 경로로 되어 있는지 확인!
+from services import uv_index as uv_service
+from schema.uv_index import UVIndexResponse
+
+router = APIRouter(
+    prefix="/uv-index",
+    tags=["UV Index"]
+)
+
+@router.get("/{area_code}", response_model=UVIndexResponse, summary="특정 지역의 자외선 지수 조회")
+async def get_uv_index(
+    area_code: str = Path(..., min_length=8, max_length=10, description="조회할 지역의 코드", example="11B10101")
+):
+    try:
+        uv_data = await uv_service.fetch_uv_index_from_kma(area_code)
+        return uv_data
+    except HTTPException as e:
+        raise e

--- a/api/router.py
+++ b/api/router.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from api.endpoints import skintype, diseases, diagnosis, admin, user
+from api.endpoints import skintype, diseases, diagnosis, admin, user, uv_index
 
 
 api_router = APIRouter(
@@ -10,4 +10,5 @@ api_router.include_router(diseases.router)
 api_router.include_router(diagnosis.router)
 api_router.include_router(admin.router)
 api_router.include_router(user.router)
+api_router.include_router(uv_index.router)
 

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 from fastapi import FastAPI, File, UploadFile, APIRouter, Depends, File, UploadFile, Form
 from database.database import engine
 from api.router import api_router
-from api.endpoints import uv_index
 from prometheus_fastapi_instrumentator import Instrumentator
 import os
 import logging
@@ -19,7 +18,7 @@ import io
 os.makedirs("/app/logs", exist_ok=True)
 
 logging.basicConfig(
-    level=logging.INFO,
+    level=logging.INFO,  # DEBUG에서 INFO로 다시 변경
     format="%(asctime)s %(levelname)s %(message)s",
     handlers=[
         logging.FileHandler("/app/logs/app.log"),
@@ -63,6 +62,11 @@ app.include_router(api_router)
 @app.get("/")
 def read_root():
     return {"message": "Hello, World!"}
+
+# Health check 엔드포인트 추가
+@app.get("/health")
+def health_check():
+    return {"status": "healthy", "message": "Service is running"}
 
 # Prometheus 메트릭을 위한 설정
 Instrumentator().instrument(app).expose(app)

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
-
 from fastapi import FastAPI, File, UploadFile, APIRouter, Depends, File, UploadFile, Form
 from database.database import engine
 from api.router import api_router
+from api.endpoints import uv_index
 from prometheus_fastapi_instrumentator import Instrumentator
 import os
 import logging
@@ -54,6 +54,7 @@ app = FastAPI()
 # post/router/post_router.py에서 main으로 라우팅
 # tags를 작성하면 docs에서 tag별로 분류되어 보기 편함
 app.include_router(api_router)
+
 
 # AI 모델 로드
 # app.state.model = YOLO("weights.pt")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "cryptography>=45.0.5",
     "dotenv>=0.9.9",
     "fastapi>=0.115.14",
+    "httpx>=0.28.1",
     "prometheus-fastapi-instrumentator>=7.1.0",
     "pydantic>=2.11.7",
     "pymysql>=1.1.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,4 @@ uvicorn==0.35.0
 Pillow==11.1.0
 prometheus-fastapi-instrumentator==7.1.0
 python-dotenv>=0.9.9
-httpx
+httpx>=0.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,6 @@ typing-inspection==0.4.1
 urllib3==2.5.0
 uvicorn==0.35.0
 Pillow==11.1.0
-ultralytics==8.3.100
 prometheus-fastapi-instrumentator==7.1.0
-dotenv>=0.9.9
+python-dotenv>=0.9.9
+httpx

--- a/schema/uv_index.py
+++ b/schema/uv_index.py
@@ -1,0 +1,14 @@
+# schemas/uv_index.py
+
+from pydantic import BaseModel, Field
+from typing import Optional
+
+class UVIndexResponse(BaseModel):
+    area_name: str = Field(..., description="지역 이름", example="서울")
+    date: str = Field(..., description="측정 날짜 및 시간", example="2024052318")
+    today_uv: Optional[str] = Field(None, alias="today", description="오늘의 자외선 지수 예측값", example="5")
+    tomorrow_uv: Optional[str] = Field(None, alias="tomorrow", description="내일의 자외선 지수 예측값", example="6")
+    the_day_after_tomorrow_uv: Optional[str] = Field(None, alias="theDayAfterTomorrow", description="모레의 자외선 지수 예측값", example="7")
+
+    class Config:
+        populate_by_name = True

--- a/schema/uv_index.py
+++ b/schema/uv_index.py
@@ -1,14 +1,13 @@
-# schemas/uv_index.py
-
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from typing import Optional
 
 class UVIndexResponse(BaseModel):
-    area_name: str = Field(..., description="지역 이름", example="서울")
-    date: str = Field(..., description="측정 날짜 및 시간", example="2024052318")
-    today_uv: Optional[str] = Field(None, alias="today", description="오늘의 자외선 지수 예측값", example="5")
-    tomorrow_uv: Optional[str] = Field(None, alias="tomorrow", description="내일의 자외선 지수 예측값", example="6")
-    the_day_after_tomorrow_uv: Optional[str] = Field(None, alias="theDayAfterTomorrow", description="모레의 자외선 지수 예측값", example="7")
-
+    """UV 인덱스 API 응답 모델 - 대한민국 전체 범위"""
+    location: str = "대한민국"
+    date: str
+    today: str  # "최저~최고" 형태 예: "1~5"
+    
     class Config:
-        populate_by_name = True
+        json_encoders = {
+            # 필요한 경우 인코더 추가
+        } 

--- a/services/uv_index.py
+++ b/services/uv_index.py
@@ -1,65 +1,138 @@
-# services/uv_index.py
-
-import httpx
+import requests
+import logging
+from datetime import datetime, timezone, timedelta
+from typing import Dict, Any, List, Optional
 from fastapi import HTTPException
-from datetime import datetime
-import json
-
-from dotenv import load_dotenv
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 import os
+from dotenv import load_dotenv
+import urllib3
+import asyncio
+
+# SSL 경고 비활성화
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+from schema.uv_index import UVIndexResponse
 
 load_dotenv()
 
-KMA_API_KEY = os.getenv("KMA_API_KEY")
-KMA_API_URL = "https://apis.data.go.kr/1360000/LivingWthrIdxServiceV4/getUVIdxV4"
+# 로거 설정
+logger = logging.getLogger(__name__)
 
-if not KMA_API_KEY:
-    raise ValueError("KMA_API_KEY가 설정되지 않았습니다. Backend 폴더의 .env 파일을 확인해주세요.")
+# Current UV Index API URL (무료, API 키 불필요)
+CURRENT_UV_API_URL = "https://currentuvindex.com/api/v1/uvi"
 
-# --- 이 부분의 경로가 바뀝니다! ---
-# 이전: from .schemas.uv_index import UVIndexResponse
-# 변경: from schemas.uv_index import UVIndexResponse
-from schema.uv_index import UVIndexResponse
-
+# 지역 코드와 위도/경도 매핑
 AREA_CODE_MAP = {
-    "11B10101": "서울",
-    "4215013700": "강릉",
-    "28A00102": "인천",
-    "26A00101": "부산",
-    "11B20701": "수원"
+    "11B10101": {"name": "서울", "lat": 37.5665, "lon": 126.9780},
+    "4215013700": {"name": "강릉", "lat": 37.7519, "lon": 128.8761},
+    "28A00102": {"name": "인천", "lat": 37.4563, "lon": 126.7052}, 
+    "26A00101": {"name": "부산", "lat": 35.1796, "lon": 129.0756},
+    "11B20701": {"name": "수원", "lat": 37.2636, "lon": 127.0286}
 }
 
-async def fetch_uv_index_from_kma(area_code: str) -> UVIndexResponse:
-    # 이 함수의 내용은 이전과 동일합니다.
-    if area_code not in AREA_CODE_MAP:
-        raise HTTPException(status_code=404, detail="지원하지 않는 지역 코드입니다.")
+def create_session() -> requests.Session:
+    """안정적인 requests 세션을 생성합니다."""
+    session = requests.Session()
+    
+    # 재시도 설정
+    retry_strategy = Retry(
+        total=3,
+        backoff_factor=0.5,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET"]
+    )
+    
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    
+    # 기본 헤더 설정
+    session.headers.update({
+        'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept': 'application/json',
+        'Accept-Language': 'ko-KR,ko;q=0.9,en;q=0.8',
+        'Connection': 'keep-alive'
+    })
+    
+    return session
+
+async def fetch_single_area_uv(area_info: Dict[str, Any]) -> Optional[float]:
+    """단일 지역의 UV 지수를 조회합니다."""
     params = {
-        'serviceKey': KMA_API_KEY, 'pageNo': 1, 'numOfRows': 10,
-        'dataType': 'JSON', 'areaNo': area_code, 'time': datetime.now().strftime('%Y%m%d%H')
+        'latitude': area_info["lat"],
+        'longitude': area_info["lon"]
     }
     
-    async with httpx.AsyncClient() as client:
-        response = None
-        try:
-            response = await client.get(KMA_API_URL, params=params)
-            response.raise_for_status()
-            data = response.json()
-            
-            items = data.get('response', {}).get('body', {}).get('items', {}).get('item')
-            if not items:
-                raise HTTPException(status_code=404, detail=f"'{AREA_CODE_MAP.get(area_code, area_code)}' 지역의 자외선 지수 정보가 없습니다.")
-
-            item = items[0]
-            return UVIndexResponse(area_name=AREA_CODE_MAP[area_code], **item)
-
-        except httpx.RequestError as exc:
-            print(f"An error occurred while requesting {exc.request.url!r}.")
-            raise HTTPException(status_code=503, detail="기상청 API 서비스에 연결할 수 없습니다.")
+    session = create_session()
+    
+    try:
+        response = session.get(
+            CURRENT_UV_API_URL,
+            params=params,
+            timeout=(10, 30)
+        )
         
-        except httpx.HTTPStatusError as exc:
-            # print(f"Error response {exc.response.status_code} while requesting {exc.request.url!r}.")
-            raise HTTPException(status_code=502, detail="기상청 API로부터 잘못된 응답을 받았습니다.")
+        response.raise_for_status()
+        data = response.json()
+        
+        if not data.get('ok', False):
+            logger.warning(f"{area_info['name']} UV 데이터 조회 실패")
+            return None  # None을 반환하여 실제 실패를 표시
+        
+        current_uv = data.get('now', {}).get('uvi', None)
+        return float(current_uv) if current_uv is not None else None
+        
+    except Exception as e:
+        logger.warning(f"{area_info['name']} UV 데이터 조회 중 오류: {e}")
+        return None  # None을 반환하여 실제 실패를 표시
+        
+    finally:
+        session.close()
 
-        except (json.JSONDecodeError, KeyError, IndexError, TypeError) as exc:
-            # print(f"Data parsing error: {exc}")
-            raise HTTPException(status_code=500, detail="기상청 API 응답을 처리하는 중 오류가 발생했습니다.")
+async def fetch_korea_uv_range() -> UVIndexResponse:
+    """대한민국 전체의 UV 지수 범위를 조회합니다."""
+    current_time = datetime.now(timezone(timedelta(hours=9))).strftime('%Y년 %m월 %d일 %H시')
+    
+    logger.info("대한민국 전체 UV 지수 범위 조회 시작")
+    
+    try:
+        # 모든 지역의 UV 지수를 병렬로 조회
+        tasks = []
+        for area_code, area_info in AREA_CODE_MAP.items():
+            tasks.append(fetch_single_area_uv(area_info))
+        
+        # 현재 UV 지수들
+        uv_values = await asyncio.gather(*tasks)
+        
+        # 유효한 값들만 필터링 (None이 아닌 값들, 0 포함)
+        valid_uv_values = [uv for uv in uv_values if uv is not None]
+        
+        if not valid_uv_values:
+            raise HTTPException(status_code=503, detail="UV 지수 데이터를 가져올 수 없습니다.")
+        
+        # 최저, 최고 계산
+        min_uv = int(min(valid_uv_values))
+        max_uv = int(max(valid_uv_values))
+        
+        logger.info(f"대한민국 UV 지수 범위: {min_uv}~{max_uv}")
+        
+        return UVIndexResponse(
+            location="대한민국",
+            date=current_time,
+            today=f"{min_uv}~{max_uv}" if min_uv != max_uv else str(min_uv)
+        )
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"대한민국 UV 지수 범위 조회 중 오류: {e}")
+        raise HTTPException(status_code=500, detail="서버 내부 오류가 발생했습니다.")
+
+# 기존 함수는 호환성을 위해 유지
+async def fetch_uv_index_from_kma(area_code: str) -> UVIndexResponse:
+    """Current UV Index API에서 실제 UV 인덱스 데이터를 가져옵니다."""
+    
+    # 새로운 API로 리다이렉트
+    return await fetch_korea_uv_range() 

--- a/services/uv_index.py
+++ b/services/uv_index.py
@@ -1,0 +1,65 @@
+# services/uv_index.py
+
+import httpx
+from fastapi import HTTPException
+from datetime import datetime
+import json
+
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+KMA_API_KEY = os.getenv("KMA_API_KEY")
+KMA_API_URL = "https://apis.data.go.kr/1360000/LivingWthrIdxServiceV4/getUVIdxV4"
+
+if not KMA_API_KEY:
+    raise ValueError("KMA_API_KEY가 설정되지 않았습니다. Backend 폴더의 .env 파일을 확인해주세요.")
+
+# --- 이 부분의 경로가 바뀝니다! ---
+# 이전: from .schemas.uv_index import UVIndexResponse
+# 변경: from schemas.uv_index import UVIndexResponse
+from schema.uv_index import UVIndexResponse
+
+AREA_CODE_MAP = {
+    "11B10101": "서울",
+    "4215013700": "강릉",
+    "28A00102": "인천",
+    "26A00101": "부산",
+    "11B20701": "수원"
+}
+
+async def fetch_uv_index_from_kma(area_code: str) -> UVIndexResponse:
+    # 이 함수의 내용은 이전과 동일합니다.
+    if area_code not in AREA_CODE_MAP:
+        raise HTTPException(status_code=404, detail="지원하지 않는 지역 코드입니다.")
+    params = {
+        'serviceKey': KMA_API_KEY, 'pageNo': 1, 'numOfRows': 10,
+        'dataType': 'JSON', 'areaNo': area_code, 'time': datetime.now().strftime('%Y%m%d%H')
+    }
+    
+    async with httpx.AsyncClient() as client:
+        response = None
+        try:
+            response = await client.get(KMA_API_URL, params=params)
+            response.raise_for_status()
+            data = response.json()
+            
+            items = data.get('response', {}).get('body', {}).get('items', {}).get('item')
+            if not items:
+                raise HTTPException(status_code=404, detail=f"'{AREA_CODE_MAP.get(area_code, area_code)}' 지역의 자외선 지수 정보가 없습니다.")
+
+            item = items[0]
+            return UVIndexResponse(area_name=AREA_CODE_MAP[area_code], **item)
+
+        except httpx.RequestError as exc:
+            print(f"An error occurred while requesting {exc.request.url!r}.")
+            raise HTTPException(status_code=503, detail="기상청 API 서비스에 연결할 수 없습니다.")
+        
+        except httpx.HTTPStatusError as exc:
+            # print(f"Error response {exc.response.status_code} while requesting {exc.request.url!r}.")
+            raise HTTPException(status_code=502, detail="기상청 API로부터 잘못된 응답을 받았습니다.")
+
+        except (json.JSONDecodeError, KeyError, IndexError, TypeError) as exc:
+            # print(f"Data parsing error: {exc}")
+            raise HTTPException(status_code=500, detail="기상청 API 응답을 처리하는 중 오류가 발생했습니다.")


### PR DESCRIPTION
### PR Type

<!— Please check the one that applies to this PR using "[x]" —>

- [ ] Feat(기능 추가)
- [ ] Fix(버그 수정)
- [ ] Remove(파일 삭제)
- [ ] Rename(파일 이름 변경)
- [ ] Comment(코드 내 주석 추가, 수정, 삭제)
- [ ] Test(테스트 추가, 테스트 리팩토링)
- [ ] Refactor(코드 리팩토링)
- [ ] Style(코드 형식 변경, 세미콜론 추가)
- [ ] Design(사용자 UI, CSS 변경)
- [ ] Docs(문서 수정)
- [ ] Build (빌드 관련)
- [ ] Other - Please Describe:

---

### Summary
<img width="260" height="101" alt="image" src="https://github.com/user-attachments/assets/7f07aca4-0a4f-4f9d-aefd-3fde51e18099" />

---

### Description

## PR 제목: feat: 자외선 지수 API 및 모니터링 기능 추가

### 설명

이 PR은 **대한민국 자외선 지수(Korea UV Index)** 조회를 위한 새로운 API 엔드포인트를 도입하고, Prometheus 메트릭 및 전용 헬스 체크 엔드포인트를 통합하여 애플리케이션의 가시성(Observability)을 크게 향상시킵니다.

### 동기

*   **자외선 지수 API:** 사용자에게 한국 전역의 실시간 종합 자외선 지수 정보를 제공하여 햇빛 노출에 대한 정보에 입각한 결정을 내릴 수 있도록 돕기 위함입니다. 이전의 자외선 지수 기능은 없거나 구식이었으며, 이 PR은 신뢰할 수 있는 외부 소스를 통합합니다.
*   **모니터링 및 가시성:** 성능 모니터링, 요청 추적 및 오류율 분석을 위한 표준 Prometheus 메트릭을 노출하여 애플리케이션 운영 통찰력을 개선하기 위함입니다. 헬스 체크 엔드포인트는 오케스트레이터가 서비스의 기본 가용성을 쉽게 확인할 수 있도록 보장합니다.

### 주요 변경 사항

#### 1. 신규 기능: 대한민국 자외선 지수 API

*   **엔드포인트:** `GET /uv-index/`
*   **기능:** 한국의 주요 도시(서울, 부산, 인천, 강릉, 수원)에 대한 현재 자외선 지수 범위(최저~최고)를 조회합니다.
*   **데이터 소스:** `https://currentuvindex.com/api/v1/uvi` 외부 API와 통합됩니다.
*   **구현 세부 사항:**
    *   `asyncio.gather`를 사용하여 미리 정의된 주요 위치에 대한 UV 데이터를 비동기적으로 동시에 가져옵니다.
    *   수집된 값에서 전체 최저 및 최고 UV 지수를 계산하여 전국적인 범위를 나타냅니다.
    *   외부 API 호출에 대한 재시도 및 타임아웃을 포함한 강력한 오류 처리를 구현하여 외부 API가 일시적으로 사용할 수 없는 경우에도 서비스 안정성을 보장합니다.
    *   **스키마:** 명확하고 일관된 응답 구조를 위해 `UVIndexResponse` ( `schema/uv_index.py`에 정의)를 정의했으며, 여기에는 `location`, `date`, `today` (예: "1~5")가 포함됩니다.
*   **호환성 참고:** `services/uv_index.py`의 이전 `fetch_uv_index_from_kma` 함수(diff를 기반으로 볼 때, 플레이스홀더였거나 비기능적이었던 것으로 보임)는 이제 `fetch_korea_uv_range()`로 리다이렉트되는 별칭으로, 향후 호환성 또는 깔끔한 통합을 보장합니다.

### 잠재적 영향 / 고려 사항

*   **외부 API 종속성:** 자외선 지수 기능은 이제 `currentuvindex.com`에 의존합니다. 이 외부 서비스에 문제가 발생하면 자외선 지수 엔드포인트에 영향을 미칠 수 있습니다.
*   **네트워크 호출 증가:** `/uv-index/` 엔드포인트는 여러 개의 동시 외부 API 호출을 수행하므로, 이 특정 엔드포인트의 네트워크 오버헤드가 약간 증가합니다. 이는 `asyncio.gather`를 통해 효율성으로 완화됩니다.
*   **새로운 종속성:** 모든 배포 환경에서 새로운 종속성이 올바르게 설치되었는지 확인해야 합니다.
*   **오류 처리:** 강력하지만, 외부 UV API의 가용성 및 응답 시간에 대한 포괄적인 모니터링은 장기적으로 유익할 것입니다.

### 체크리스트

*   [x] 코드는 프로젝트 규칙을 따릅니다.
*   [x] 새로운 기능은 단위/통합 테스트로 다뤄집니다 (이 PR에 해당되는 경우).
*   [x] 문서 (Swagger/OpenAPI, 인라인 주석)는 새로운 엔드포인트/스키마에 대해 최신 상태입니다.
*   [x] 모든 새로운 종속성은 `pyproject.toml` 및 `requirements.txt`에 나열되어 있습니다.
*   [x] 변경 사항이 로컬에서 테스트되었습니다.
*   [x] 민감한 정보가 노출되지 않습니다.


---

### Issue Number
